### PR TITLE
Prevent lock guard from being dropped prematurely

### DIFF
--- a/src/wireguard/wireguard.rs
+++ b/src/wireguard/wireguard.rs
@@ -206,10 +206,10 @@ impl<T: Tun, B: UDP> WireGuard<T, B> {
         }
 
         // prevent up/down while inserting
-        let enabled = *self.enabled.read();
+        let enabled = self.enabled.read();
 
         // create timers (lookup by public key)
-        let timers = Timers::new::<T, B>(self.clone(), pk.clone(), enabled);
+        let timers = Timers::new::<T, B>(self.clone(), pk.clone(), *enabled);
 
         // create new router peer
         let peer: router::PeerHandle<B::Endpoint, PeerInner<T, B>, T::Writer, B::Writer> =


### PR DESCRIPTION
Hello :)

I stumbled upon this line and it seemed to drop the lock prematurely. I think this will happen because the dereference operator will cause the `self.enabled.read()` result to be stored in a temporary variable that is immediately dropped as soon as the copy from the dereferenced value is complete.

The comment above the declaration line says that it should prevent up/down events while inserting, and I think that won't happen if the lock is dropped prematurely. I moved the dereference operator so that the temporary variable isn't created, and the lock guard is only dropped at the end of the function.