### PR TITLE
Allow building crate as library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+pub mod configuration;
+pub mod platform;
+pub mod wireguard;


### PR DESCRIPTION
Added a `src/lib.rs` file to allow building the crate as a library.