### PR TITLE
Fix time::Instant underflow in handshake 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+pub mod configuration;
+pub mod platform;
+pub mod wireguard;


### PR DESCRIPTION
On macOS, `time::Instant::now() - time::Duration::from_secs(86400)` would panic due to an underflow if the machine was running for less than 24 hours. This of course is not ideal, as that expression is used to initialize the cookie validator. I've worked around this by making the birth of the secret optional, and just assume that a secret without a birthday is invalid. This could also be changed to have the secret itself be optional.