### PR TITLE
Improve tunnel writer trait

### DIFF
--- a/src/platform/linux/tun.rs
+++ b/src/platform/linux/tun.rs
@@ -106,8 +106,9 @@ impl Reader for LinuxTunReader {
 impl Writer for LinuxTunWriter {
     type Error = LinuxTunError;
 
-    fn write(&self, src: &[u8]) -> Result<(), Self::Error> {
-        match unsafe { libc::write(self.fd, src.as_ptr() as _, src.len() as _) } {
+    fn write(&self, src: &[u8], offset: usize) -> Result<(), Self::Error> {
+        let data = &src[offset..];
+        match unsafe { libc::write(self.fd, data.as_ptr() as _, data.len() as _) } {
             -1 => Err(LinuxTunError::Closed),
             _ => Ok(()),
         }

--- a/src/platform/tun.rs
+++ b/src/platform/tun.rs
@@ -25,7 +25,7 @@ pub trait Writer: Send + Sync + 'static {
     /// # Returns
     ///
     /// Unit type or an error
-    fn write(&self, src: &[u8]) -> Result<(), Self::Error>;
+    fn write(&self, src: &mut [u8], offset: usize) -> Result<(), Self::Error>;
 }
 
 pub trait Reader: Send + 'static {

--- a/src/wireguard/router/receive.rs
+++ b/src/wireguard/router/receive.rs
@@ -173,7 +173,7 @@ impl<E: Endpoint, C: Callbacks, T: tun::Writer, B: udp::Writer<E>> SequentialJob
         // (keep-alive and malformed packets will have no inner length)
         if let Some(inner) = inner_length(packet) {
             if inner + SIZE_TAG <= packet.len() {
-                let _ = peer.device.inbound.write(&packet[..inner]).map_err(|e| {
+                let _ = peer.device.inbound.write(&packet, inner).map_err(|e| {
                     log::debug!("failed to write inbound packet to TUN: {:?}", e);
                 });
             }


### PR DESCRIPTION
The tunnel reader trait as used on macOS (#18) forces a copy of the received traffic since macOS's `utun` requires extra header to be passed into the tunnel interface when receiving tunnel traffic. Since the `Writer::write` method takes a single parameter that is the slice of bytes that should be written to the `utun` device, and the slice doesn't contain the headers `utun` expects, the slice has to be copied and a buffer needs to be allocated. Since the header on macOS are always 4 bytes long, it will always be smaller than the wireguard header that's preceding the payload in the buffer that's originally backing the slice. 

This seems like a bit of a hack, and I'm open to better suggestions to reducing the amount of copying required.